### PR TITLE
Bugfix: including square brackets and curly braces in rm_qwerty_keymap

### DIFF
--- a/apps/yaft/keymap.cpp
+++ b/apps/yaft/keymap.cpp
@@ -152,6 +152,8 @@ const KeyMap rm_qwerty_keymap = {
   { KEY_I, { 'I' } },
   { KEY_O, { 'O' } },
   { KEY_P, { 'P' } },
+  { KEY_LEFTBRACE, { '[', '{' } },
+  { KEY_RIGHTBRACE, { ']', '}' } },
   { KEY_ENTER, { Enter } },
   { KEY_LEFTCTRL, { Ctrl } },
   { KEY_A, { 'A' } },


### PR DESCRIPTION
This fix allows Yaft to accept square bracket and curly brace characters entered from the type folio via keyd.